### PR TITLE
FISH-6195 Add extra logging and remove redundant logger

### DIFF
--- a/src/main/java/fish/payara/extras/upgrade/BaseUpgradeCommand.java
+++ b/src/main/java/fish/payara/extras/upgrade/BaseUpgradeCommand.java
@@ -165,18 +165,23 @@ public abstract class BaseUpgradeCommand extends LocalDomainCommand {
             logger.log(Level.INFO, "Reinstalling nodes for domain " + domaindir.getName());
             boolean throwException = false;
             List<String> failingNodes = new ArrayList<>();
-            for (Node node : doc.getRoot().createProxy(Domain.class).getNodes().getNode()) {
-                if (node.getType().equals("SSH")) {
-                    boolean commandSuccess = reinstallSSHNode(node);
-                    if (!commandSuccess) {
-                        throwException = true;
-                        failingNodes.add(node.getName());
+            List<Node> nodes = doc.getRoot().createProxy(Domain.class).getNodes().getNode();
+            if (!nodes.isEmpty()) {
+                for (Node node : nodes) {
+                    if (node.getType().equals("SSH")) {
+                        boolean commandSuccess = reinstallSSHNode(node);
+                        if (!commandSuccess) {
+                            throwException = true;
+                            failingNodes.add(node.getName());
+                        }
+                    } else if(!node.isDefaultLocalNode()) {
+                        logger.log(Level.WARNING, String.format("Only the SSH nodes are upgraded by this tool, " +
+                                        "please upgrade your node with name %s of type %s manually", node.getName(),
+                                node.getType()));
                     }
-                } else if(!node.isDefaultLocalNode()) {
-                    logger.log(Level.WARNING, String.format("Only the SSH nodes are upgraded by this tool, " +
-                                    "please upgrade your node with name %s of type %s manually", node.getName(),
-                            node.getType()));
                 }
+            } else {
+                logger.log(Level.FINE, "No nodes found for domain {0}", domaindir.getName());
             }
 
             if (throwException) {

--- a/src/main/java/fish/payara/extras/upgrade/BaseUpgradeCommand.java
+++ b/src/main/java/fish/payara/extras/upgrade/BaseUpgradeCommand.java
@@ -271,6 +271,11 @@ public abstract class BaseUpgradeCommand extends LocalDomainCommand {
         } catch (ProcessManagerException ex) {
             logger.log(Level.SEVERE, "Error while executing command: {0}", ex.getMessage());
             commandSuccess = false;
+
+            if (ex.getMessage().contains("process hasn't exited")) {
+                logger.log(Level.SEVERE, "ProcessManager executing `install-node-ssh` command did not exit - " +
+                        "it may have timed out.");
+            }
         }
 
         return commandSuccess;

--- a/src/main/java/fish/payara/extras/upgrade/BaseUpgradeCommand.java
+++ b/src/main/java/fish/payara/extras/upgrade/BaseUpgradeCommand.java
@@ -40,7 +40,6 @@
 
 package fish.payara.extras.upgrade;
 
-import com.sun.enterprise.admin.cli.CLICommand;
 import com.sun.enterprise.admin.servermgmt.cli.LocalDomainCommand;
 import com.sun.enterprise.config.serverbeans.Domain;
 import com.sun.enterprise.config.serverbeans.Node;
@@ -79,15 +78,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.stream.Stream;
 
 /**
  * Base class containing shared methods and variables used by other upgrade/rollback commands.
  */
 public abstract class BaseUpgradeCommand extends LocalDomainCommand {
-
-    protected static final Logger LOGGER = Logger.getLogger(CLICommand.class.getPackage().getName());
 
     // The property present in the upgrade-tool properties file
     protected static final String PAYARA_UPGRADE_DIRS_PROP = "PAYARA_UPGRADE_DIRS";
@@ -125,9 +121,11 @@ public abstract class BaseUpgradeCommand extends LocalDomainCommand {
 
         // Set up the install dir variable
         glassfishDir = getInstallRootPath();
+        logger.log(Level.FINEST, "glassfishDir resolved as {0}", glassfishDir);
 
         // Gets all folders and files to be moved in the upgrade process, including osgi-cache directories
         moveFolders = Stream.concat(Arrays.stream(CONSTANTMOVEFOLDERS), Arrays.stream(getOsgiCacheDirectories())).toArray((String[]::new));
+        logger.log(Level.FINEST, "moveFolders resolved as {0}", String.join(", ", moveFolders));
     }
 
     private String[] getOsgiCacheDirectories() {
@@ -157,14 +155,14 @@ public abstract class BaseUpgradeCommand extends LocalDomainCommand {
             try {
                 parser.logUnrecognisedElements(false);
             } catch (NoSuchMethodError noSuchMethodError) {
-                LOGGER.log(Level.FINE,
+                logger.log(Level.FINE,
                         "Using a version of ConfigParser that does not support disabling log messages via method",
                         noSuchMethodError);
             }
 
             URL domainURL = domainXMLFile.toURI().toURL();
             DomDocument doc = parser.parse(domainURL);
-            LOGGER.log(Level.INFO, "Reinstalling nodes for domain " + domaindir.getName());
+            logger.log(Level.INFO, "Reinstalling nodes for domain " + domaindir.getName());
             boolean throwException = false;
             List<String> failingNodes = new ArrayList<>();
             for (Node node : doc.getRoot().createProxy(Domain.class).getNodes().getNode()) {
@@ -175,7 +173,7 @@ public abstract class BaseUpgradeCommand extends LocalDomainCommand {
                         failingNodes.add(node.getName());
                     }
                 } else if(!node.isDefaultLocalNode()) {
-                    LOGGER.log(Level.WARNING, String.format("Only the SSH nodes are upgraded by this tool, " +
+                    logger.log(Level.WARNING, String.format("Only the SSH nodes are upgraded by this tool, " +
                                     "please upgrade your node with name %s of type %s manually", node.getName(),
                             node.getType()));
                 }
@@ -195,7 +193,7 @@ public abstract class BaseUpgradeCommand extends LocalDomainCommand {
                 try {
                     urls.add(file.toURI().toURL());
                 } catch (MalformedURLException malformedURLException) {
-                    LOGGER.log(Level.SEVERE, "Error reading from modules directory "
+                    logger.log(Level.SEVERE, "Error reading from modules directory "
                             + Paths.get(glassfishDir, "modules"));
                     throw new CommandException(malformedURLException);
                 }
@@ -213,7 +211,7 @@ public abstract class BaseUpgradeCommand extends LocalDomainCommand {
         try {
             serviceLocator = registry.createServiceLocator("default");
         } catch (MultiException multiException) {
-            LOGGER.log(Level.SEVERE, "Error creating service locator - something went wrong initialising " +
+            logger.log(Level.SEVERE, "Error creating service locator - something went wrong initialising " +
                     "service locator using modules directory " + Paths.get(glassfishDir, "modules"));
             throw new CommandException(multiException);
         }
@@ -222,7 +220,7 @@ public abstract class BaseUpgradeCommand extends LocalDomainCommand {
     }
 
     protected boolean reinstallSSHNode(Node node) {
-        LOGGER.log(Level.INFO, "Reinstalling SSH node {0}", new Object[]{node.getName()});
+        logger.log(Level.INFO, "Reinstalling SSH node {0}", new Object[]{node.getName()});
         ArrayList<String> command = new ArrayList<>();
         SshConnector sshConnector = node.getSshConnector();
         SshAuth sshAuth = sshConnector.getSshAuth();
@@ -287,7 +285,7 @@ public abstract class BaseUpgradeCommand extends LocalDomainCommand {
     }
 
     protected void deleteStagedInstall() throws IOException {
-        LOGGER.log(Level.FINE, "Deleting staged install if present");
+        logger.log(Level.FINE, "Deleting staged install if present");
         DeleteFileVisitor visitor = new DeleteFileVisitor();
         for (String folder : moveFolders) {
             // Only attempt to delete folders which exist
@@ -295,9 +293,11 @@ public abstract class BaseUpgradeCommand extends LocalDomainCommand {
             Path folderPath = Paths.get(glassfishDir, folder + ".new");
             if (folderPath.toFile().exists()) {
                 Files.walkFileTree(folderPath, visitor);
+            } else {
+                logger.log(Level.FINEST, "Staged file {0} does not exist, skipping", folderPath.toString());
             }
         }
-        LOGGER.log(Level.FINE, "Deleted staged install");
+        logger.log(Level.FINE, "Deleted staged install");
     }
 
     protected class CopyFileVisitor implements FileVisitor<Path> {
@@ -317,15 +317,20 @@ public abstract class BaseUpgradeCommand extends LocalDomainCommand {
 
         @Override
         public FileVisitResult visitFile(Path arg0, BasicFileAttributes arg1) throws IOException {
+            logger.log(Level.FINER, "Copying file {0}", arg0.toString());
+
             Path resolvedPath = targetPath.resolve(sourcePath.relativize(arg0));
+            logger.log(Level.FINEST, "Copying to {0}", resolvedPath.toString());
 
             File parentFile = resolvedPath.toFile().getParentFile();
             if (!parentFile.exists()) {
+                logger.log(Level.FINEST, "Parent file does not exist, creating: {0}", parentFile.toString());
                 parentFile.mkdirs();
             }
 
             Files.copy(arg0, resolvedPath, StandardCopyOption.REPLACE_EXISTING);
 
+            logger.log(Level.FINEST, "Copied file {0} to {1}", new Object[]{arg0.toString(), resolvedPath.toString()});
             return FileVisitResult.CONTINUE;
         }
 
@@ -335,12 +340,12 @@ public abstract class BaseUpgradeCommand extends LocalDomainCommand {
             // optional with "useDownloaded"), so specifically catch a NSFE for the MQ directory.
             if (arg1 instanceof NoSuchFileException && arg1.getMessage().contains(
                     "payara5" + File.separator + "glassfish" + File.separator + ".." + File.separator + "mq")) {
-                LOGGER.log(Level.FINE, "Ignoring NoSuchFileException for mq directory under assumption " +
+                logger.log(Level.FINE, "Ignoring NoSuchFileException for mq directory under assumption " +
                         "this is a payara-web distribution. Continuing copy...");
                 return FileVisitResult.SKIP_SUBTREE;
             }
 
-            LOGGER.log(Level.SEVERE, "File could not visited: {0}", arg0.toString());
+            logger.log(Level.SEVERE, "File could not visited: {0}", arg0.toString());
             throw arg1;
         }
 
@@ -360,7 +365,9 @@ public abstract class BaseUpgradeCommand extends LocalDomainCommand {
 
         @Override
         public FileVisitResult visitFile(Path arg0, BasicFileAttributes arg1) throws IOException {
+            logger.log(Level.FINER, "Deleting file {0}", arg0.toString());
             arg0.toFile().delete();
+            logger.log(Level.FINEST, "Deleted file {0}", arg0.toString());
             return FileVisitResult.CONTINUE;
         }
 
@@ -368,18 +375,20 @@ public abstract class BaseUpgradeCommand extends LocalDomainCommand {
         public FileVisitResult visitFileFailed(Path arg0, IOException arg1) throws IOException {
             // Don't fail out on NSFE, just try to delete all of them
             if (arg1 instanceof NoSuchFileException) {
-                LOGGER.log(Level.FINE, "Ignoring NoSuchFileException for directory {0} and continuing cleanup.",
+                logger.log(Level.FINE, "Ignoring NoSuchFileException for directory {0} and continuing cleanup.",
                         arg0.toString());
                 return FileVisitResult.SKIP_SUBTREE;
             }
 
-            LOGGER.log(Level.SEVERE, "File could not deleted: {0}", arg0.toString());
+            logger.log(Level.SEVERE, "File could not deleted: {0}", arg0.toString());
             throw arg1;
         }
 
         @Override
         public FileVisitResult postVisitDirectory(Path arg0, IOException arg1) throws IOException {
+            logger.log(Level.FINER, "Deleting file {0}", arg0.toString());
             arg0.toFile().delete();
+            logger.log(Level.FINEST, "Deleted file {0}", arg0.toString());
             return FileVisitResult.CONTINUE;
         }
 

--- a/src/main/java/fish/payara/extras/upgrade/BaseUpgradeCommand.java
+++ b/src/main/java/fish/payara/extras/upgrade/BaseUpgradeCommand.java
@@ -165,22 +165,24 @@ public abstract class BaseUpgradeCommand extends LocalDomainCommand {
             logger.log(Level.INFO, "Reinstalling nodes for domain " + domaindir.getName());
             boolean throwException = false;
             List<String> failingNodes = new ArrayList<>();
-            List<Node> nodes = doc.getRoot().createProxy(Domain.class).getNodes().getNode();
-            if (!nodes.isEmpty()) {
-                for (Node node : nodes) {
-                    if (node.getType().equals("SSH")) {
-                        boolean commandSuccess = reinstallSSHNode(node);
-                        if (!commandSuccess) {
-                            throwException = true;
-                            failingNodes.add(node.getName());
-                        }
-                    } else if(!node.isDefaultLocalNode()) {
-                        logger.log(Level.WARNING, String.format("Only the SSH nodes are upgraded by this tool, " +
-                                        "please upgrade your node with name %s of type %s manually", node.getName(),
-                                node.getType()));
+            boolean foundNode = false;
+            for (Node node : doc.getRoot().createProxy(Domain.class).getNodes().getNode()) {
+                if (node.getType().equals("SSH")) {
+                    foundNode = true;
+                    boolean commandSuccess = reinstallSSHNode(node);
+                    if (!commandSuccess) {
+                        throwException = true;
+                        failingNodes.add(node.getName());
                     }
+                } else if (!node.isDefaultLocalNode()) {
+                    foundNode = true;
+                    logger.log(Level.WARNING, String.format("Only the SSH nodes are upgraded by this tool, " +
+                                    "please upgrade your node with name %s of type %s manually", node.getName(),
+                            node.getType()));
                 }
-            } else {
+            }
+
+            if (!foundNode) {
                 logger.log(Level.FINE, "No nodes found for domain {0}", domaindir.getName());
             }
 

--- a/src/main/java/fish/payara/extras/upgrade/ReinstallNodesCommand.java
+++ b/src/main/java/fish/payara/extras/upgrade/ReinstallNodesCommand.java
@@ -66,7 +66,7 @@ public class ReinstallNodesCommand extends BaseUpgradeCommand {
              * least one upgrade hit an error. Since we don't know if this was all nodes or just a subset,
              * pessimistically log a full error rather than a warning.
              */
-            LOGGER.log(Level.SEVERE, "Failed to reinstall all nodes: inspect the logs from this command for " +
+            logger.log(Level.SEVERE, "Failed to reinstall all nodes: inspect the logs from this command for " +
                             "the reasons. You can roll back or upgrade the node installs individually using the " +
                             "rollback-server or upgrade-server commands on each node respectively, or attempt to " +
                             "reinstall them again by re-running this command \n{0}",

--- a/src/main/java/fish/payara/extras/upgrade/ReinstallNodesCommand.java
+++ b/src/main/java/fish/payara/extras/upgrade/ReinstallNodesCommand.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2021 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021-2022 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/src/main/java/fish/payara/extras/upgrade/UpgradeServerCommand.java
+++ b/src/main/java/fish/payara/extras/upgrade/UpgradeServerCommand.java
@@ -318,6 +318,8 @@ public class UpgradeServerCommand extends BaseUpgradeCommand {
      * @throws CommandException If the distribution doesn't match.
      */
     private void validateDistribution() throws CommandValidationException {
+        logger.log(Level.FINER, "Validating distribution");
+
         // Get current Payara distribution
         String versionDistribution = "";
         try {
@@ -329,7 +331,7 @@ public class UpgradeServerCommand extends BaseUpgradeCommand {
         // Check if distribution is defined.
         // Continue with upgrade if no defined distribution, user should be able rollback if needed.
         if (versionDistribution.isEmpty()) {
-            System.out.println("The distribution cannot be validated.");
+            logger.log(Level.INFO, "The distribution cannot be validated.");
             return;
         }
 
@@ -338,6 +340,8 @@ public class UpgradeServerCommand extends BaseUpgradeCommand {
             throw new CommandValidationException(String.format("The current distribution (%s) you are " +
                     "running does not match the requested upgrade distribution (%s)", versionDistribution, distribution));
         }
+
+        logger.log(Level.FINE, "Distribution validated as {0}", versionDistribution);
     }
 
     @Override
@@ -374,11 +378,19 @@ public class UpgradeServerCommand extends BaseUpgradeCommand {
 
         // Delete existing property file if present
         Path upgradeToolPropertiesPath = Paths.get(glassfishDir, "config", "upgrade-tool.properties");
-        try {
-            Files.deleteIfExists(upgradeToolPropertiesPath);
-        } catch (IOException ioException) {
-            throw new CommandValidationException("Encountered an error trying to existing delete " +
-                    "upgrade-tool.properties file:\n", ioException);
+        logger.log(Level.FINER, "Creating upgrade-tool.properties file: {0}", upgradeToolPropertiesPath.toString());
+
+        if (Files.exists(upgradeToolPropertiesPath)) {
+            try {
+                logger.log(Level.FINER, "Deleting pre-existing upgrade-tool.properties file: {0}",
+                        upgradeToolPropertiesPath.toString());
+                Files.delete(upgradeToolPropertiesPath);
+                logger.log(Level.FINER, "Deleted pre-existing upgrade-tool.properties file: {0}",
+                        upgradeToolPropertiesPath.toString());
+            } catch (IOException ioException) {
+                throw new CommandValidationException("Encountered an error trying to existing delete " +
+                        "upgrade-tool.properties file:\n", ioException);
+            }
         }
 
         // Create new property file and populate
@@ -387,11 +399,15 @@ public class UpgradeServerCommand extends BaseUpgradeCommand {
             bufferedWriter.append(PAYARA_UPGRADE_DIRS_PROP + "=");
 
             // Add the move folders, separated by commas
-            bufferedWriter.append(String.join(",", folders));
+            String joinedFolders = String.join(",", folders);
+            logger.log(Level.FINEST, "Populating upgrade-tool.properties with move folders: {0}", joinedFolders);
+            bufferedWriter.append(joinedFolders);
         } catch (IOException ioException) {
             throw new CommandValidationException("Encountered an error trying to write upgrade-tool.properties file:\n",
                     ioException);
         }
+        logger.log(Level.FINER, "Finished creating upgrade-tool.properties file: {0}",
+                upgradeToolPropertiesPath.toString());
     }
 
     /**
@@ -411,11 +427,18 @@ public class UpgradeServerCommand extends BaseUpgradeCommand {
 
         // Delete existing property file if present
         Path upgradeToolBatPath = Paths.get(glassfishDir, "config", "upgrade-tool.bat");
-        try {
-            Files.deleteIfExists(upgradeToolBatPath);
-        } catch (IOException ioException) {
-            throw new CommandValidationException("Encountered an error trying to existing delete " +
-                    "upgrade-tool.bat file:\n", ioException);
+        logger.log(Level.FINER, "Creating upgrade-tool.bat file: {0}", upgradeToolBatPath.toString());
+        if (Files.exists(upgradeToolBatPath)) {
+            try {
+                logger.log(Level.FINER, "Deleting pre-existing upgrade-tool.bat file: {0}",
+                        upgradeToolBatPath.toString());
+                Files.delete(upgradeToolBatPath);
+                logger.log(Level.FINEST, "Deleted pre-existing upgrade-tool.bat file: {0}",
+                        upgradeToolBatPath.toString());
+            } catch (IOException ioException) {
+                throw new CommandValidationException("Encountered an error trying to existing delete " +
+                        "upgrade-tool.bat file:\n", ioException);
+            }
         }
 
         // Create new property file and populate
@@ -424,11 +447,14 @@ public class UpgradeServerCommand extends BaseUpgradeCommand {
             bufferedWriter.append("SET " + PAYARA_UPGRADE_DIRS_PROP + "=");
 
             // Add the move folders, separated by commas
-            bufferedWriter.append(String.join(",", folders));
+            String joinedFolders = String.join(",", folders);
+            logger.log(Level.FINEST, "Populating upgrade-tool.bat with move folders: {0}", joinedFolders);
+            bufferedWriter.append(joinedFolders);
         } catch (IOException ioException) {
             throw new CommandValidationException("Encountered an error trying to write upgrade-tool.bat file:\n",
                     ioException);
         }
+        logger.log(Level.FINER, "Finished creating upgrade-tool.bat file: {0}", upgradeToolBatPath.toString());
     }
 
     @Override
@@ -440,41 +466,50 @@ public class UpgradeServerCommand extends BaseUpgradeCommand {
         Path unzippedDirectory = null;
 
         // here the upgrade starts with non-restorable changes, display warning
-        LOGGER.log(Level.WARNING, "Do not interrupt the upgrade process, do not shutdown the server or computer.");
+        logger.log(Level.WARNING, "Do not interrupt the upgrade process, do not shutdown the server or computer.");
 
         // Download and/or unzip payara distribution, aborting upgrade if this fails
         try {
             Path tempFile = Files.createTempFile("payara", ".zip");
 
             if (useDownloadedFile != null) {
+                logger.log(Level.FINER, "Copying downloaded distribution {0} to temp file: {1}",
+                        new Object[]{useDownloadedFile.toString(), tempFile.toString()});
                 Files.copy(useDownloadedFile.toPath(), tempFile, StandardCopyOption.REPLACE_EXISTING);
+                logger.log(Level.FINEST, "Copied downloaded distribution {0} to temp file: {1}",
+                        new Object[]{useDownloadedFile.toString(), tempFile.toString()});
             } else {
-                LOGGER.log(Level.INFO, "Downloading new Payara version...");
+                logger.log(Level.INFO, "Downloading new Payara version...");
+                logger.log(Level.FINE, "Downloading from {0}", url);
                 HttpURLConnection connection = getConnection(url);
                 connection.setRequestProperty("Authorization", authBytes);
 
                 int code = connection.getResponseCode();
                 if (code != 200) {
                     if (code == 404) {
-                        LOGGER.log(Level.SEVERE, "The version indicated is incorrect, please set correct version and try again");
+                        logger.log(Level.SEVERE, "The version indicated is incorrect, please set correct version and try again");
                         throw new CommandValidationException("Payara version not found");
                     } else {
-                        LOGGER.log(Level.SEVERE, "Error connecting to server: {0}", code);
+                        logger.log(Level.SEVERE, "Error connecting to server: {0}", code);
                         return ERROR;
                     }
                 }
 
+                logger.log(Level.FINER, "Copying downloaded distribution to temp file: {0}", tempFile);
                 Files.copy(connection.getInputStream(), tempFile, StandardCopyOption.REPLACE_EXISTING);
+                logger.log(Level.FINEST, "Copied downloaded distribution to temp file: {0}", tempFile);
             }
 
             FileInputStream unzipFileStream = new FileInputStream(tempFile.toFile());
+            logger.log(Level.FINE, "Extracting zip file {0}", tempFile.toString());
             unzippedDirectory = extractZipFile(unzipFileStream);
+            logger.log(Level.FINEST, "Extracted zip file {0}", tempFile.toString());
         } catch (IOException | CommandException e) {
-            LOGGER.log(Level.SEVERE, String.format("Error preparing for upgrade, aborting upgrade: %s", e));
+            logger.log(Level.SEVERE, String.format("Error preparing for upgrade, aborting upgrade: %s", e));
             return ERROR;
         }
         if (unzippedDirectory == null) {
-            LOGGER.log(Level.SEVERE, "Error preparing for upgrade, aborting upgrade: could not extract archive");
+            logger.log(Level.SEVERE, "Error preparing for upgrade, aborting upgrade: could not extract archive");
             return ERROR;
         }
 
@@ -482,14 +517,14 @@ public class UpgradeServerCommand extends BaseUpgradeCommand {
         try {
             backupDomains();
         } catch (CommandException ce) {
-            LOGGER.log(Level.SEVERE, "Error executing backup-domain command, aborting upgrade: {0}", ce.toString());
+            logger.log(Level.SEVERE, "Error executing backup-domain command, aborting upgrade: {0}", ce.toString());
             return ERROR;
         }
 
         try {
             cleanupExisting();
         } catch (IOException ioe) {
-            LOGGER.log(Level.SEVERE, "Error cleaning up previous upgrades, aborting upgrade: {0}", ioe.toString());
+            logger.log(Level.SEVERE, "Error cleaning up previous upgrades, aborting upgrade: {0}", ioe.toString());
             return ERROR;
         }
 
@@ -500,7 +535,7 @@ public class UpgradeServerCommand extends BaseUpgradeCommand {
                 fixPermissions();
             }
         } catch (IOException ex) {
-            LOGGER.log(Level.SEVERE, "Error upgrading Payara Server, rolling back upgrade: {0}", ex.toString());
+            logger.log(Level.SEVERE, "Error upgrading Payara Server, rolling back upgrade: {0}", ex.toString());
 
             try {
                 if (stage) {
@@ -509,7 +544,7 @@ public class UpgradeServerCommand extends BaseUpgradeCommand {
                     undoMoveFiles();
                 }
             } catch (IOException ex1) {
-                LOGGER.log(Level.WARNING, "Failed to restore previous state: {0}", ex.toString());
+                logger.log(Level.WARNING, "Failed to restore previous state: {0}", ex.toString());
             }
             return ERROR;
         }
@@ -522,7 +557,7 @@ public class UpgradeServerCommand extends BaseUpgradeCommand {
                 // IOException or ConfigurationException occurs when parsing the domain.xml, before any attempt to
                 // update the nodes. It gets thrown if the domain.xml couldn't be found, or if the domain.xml is
                 // somehow incorrect, which implies something has gone wrong - rollback
-                LOGGER.log(Level.SEVERE, "Error upgrading Payara Server nodes, rolling back: {0}", ex.toString());
+                logger.log(Level.SEVERE, "Error upgrading Payara Server nodes, rolling back: {0}", ex.toString());
                 try {
                     if (stage) {
                         deleteStagedInstall();
@@ -531,7 +566,7 @@ public class UpgradeServerCommand extends BaseUpgradeCommand {
                     }
                 } catch (IOException ex1) {
                     // Exit out here if we failed to restore, we don't want to push a broken install to the nodes
-                    LOGGER.log(Level.SEVERE, "Failed to restore previous state of local install", ex1.toString());
+                    logger.log(Level.SEVERE, "Failed to restore previous state of local install", ex1.toString());
                     return ERROR;
                 }
 
@@ -540,7 +575,7 @@ public class UpgradeServerCommand extends BaseUpgradeCommand {
             } catch (CommandException ce) {
                 // CommandException gets thrown once all nodes have been attempted to be upgraded and if at
                 // least one upgrade hit an error. We don't want to roll back now since the failure might be valid
-                LOGGER.log(Level.WARNING, "Failed to upgrade all nodes: inspect the logs from this command for " +
+                logger.log(Level.WARNING, "Failed to upgrade all nodes: inspect the logs from this command for " +
                                 "the reasons. You can rollback the server upgrade and all of its nodes using the " +
                                 "rollback-server command, upgrade the node installs individually using the " +
                                 "upgrade-server command on each node, or attempt to upgrade them all again using the " +
@@ -551,7 +586,7 @@ public class UpgradeServerCommand extends BaseUpgradeCommand {
         }
 
         if (stage) {
-            LOGGER.log(Level.INFO,
+            logger.log(Level.INFO,
                     "Upgrade successfully staged, please run the applyStagedUpgrade script to apply the upgrade. " +
                             "It can be found under payara5/glassfish/bin.");
         }
@@ -574,6 +609,7 @@ public class UpgradeServerCommand extends BaseUpgradeCommand {
     private Path extractZipFile(InputStream remote) throws IOException {
         Path tempDirectory = Files.createTempDirectory("payara-new");
 
+        logger.log(Level.FINER, "Extracting zip file to temp directory {0}", tempDirectory.toString());
         try (ZipInputStream zipInput = new ZipInputStream(remote)) {
             ZipEntry entry = zipInput.getNextEntry();
             while (entry != null) {
@@ -593,24 +629,28 @@ public class UpgradeServerCommand extends BaseUpgradeCommand {
                 entry = zipInput.getNextEntry();
             }
         }
+        logger.log(Level.FINEST, "Extracted zip file to temp directory {0}", tempDirectory.toString());
         return tempDirectory;
     }
 
     private void backupDomains() throws CommandException {
-        LOGGER.log(Level.INFO, "Backing up domain configs");
+        logger.log(Level.INFO, "Backing up domain configs");
         File[] domaindirs = getDomainsDir().listFiles(File::isDirectory);
         for (File domaindir : domaindirs) {
             CLICommand backupDomainCommand = CLICommand.getCommand(habitat, "backup-domain");
             if (StringUtils.ok(domainDirParam)) {
+                logger.log(Level.FINE, "Executing command: {0}", "backup-domain --domaindir "
+                        + domainDirParam + " " + domaindir.getName());
                 backupDomainCommand.execute("backup-domain", "--domaindir", domainDirParam, domaindir.getName());
             } else {
+                logger.log(Level.FINE, "Executing command: {0}", "backup-domain " + domaindir.getName());
                 backupDomainCommand.execute("backup-domain", domaindir.getName());
             }
         }
     }
 
     private void cleanupExisting() throws IOException {
-        LOGGER.log(Level.FINE, "Deleting old server backup if present");
+        logger.log(Level.FINE, "Deleting old server backup if present");
         DeleteFileVisitor visitor = new DeleteFileVisitor();
         for (String folder : moveFolders) {
             Path folderPath = Paths.get(glassfishDir, folder + ".old");
@@ -618,28 +658,35 @@ public class UpgradeServerCommand extends BaseUpgradeCommand {
             // Don't fail out if it doesn't exist, just keep going - we want to delete all we can
             if (folderPath.toFile().exists()) {
                 Files.walkFileTree(folderPath, visitor);
+            } else {
+                logger.log(Level.FINER, "No old install directory found for {0}, skipping", folderPath.toString());
             }
         }
-        LOGGER.log(Level.FINE, "Deleted old server backup");
+        logger.log(Level.FINE, "Deleted old server backup");
         deleteStagedInstall();
     }
 
     private void moveFiles(Path newVersion) throws IOException {
         if (!stage) {
-            LOGGER.log(Level.FINE, "Moving files to old");
+            logger.log(Level.FINE, "Moving files to old");
             for (String folder : moveFolders) {
                 try {
                     // Just attempt to move all folders - any exceptions aside from NoSuchFile on an MQ directory
                     // are unexpected and we should cancel out if we hit one
-                    Files.move(Paths.get(glassfishDir, folder), Paths.get(glassfishDir, folder + ".old"),
-                            StandardCopyOption.REPLACE_EXISTING);
+                    Path currentFile = Paths.get(glassfishDir, folder);
+                    Path oldFile = Paths.get(glassfishDir, folder + ".old");
+                    logger.log(Level.FINER, "Moving current install file {0} to old directory {1}",
+                            new Object[]{currentFile.toString(), oldFile.toString()});
+                    Files.move(currentFile, oldFile, StandardCopyOption.REPLACE_EXISTING);
+                    logger.log(Level.FINEST, "Moved current install file {0} to old directory {1}",
+                            new Object[]{currentFile.toString(), oldFile.toString()});
                 } catch (NoSuchFileException nsfe) {
                     // We can't nicely check if the "current" installation is a web distribution or not ("distribution"
                     // param is optional with "useDownloaded"), so just attempt to move all and specifically catch a
                     // NSFE for the MQ directory
                     if (nsfe.getMessage().contains(
                             "payara5" + File.separator + "glassfish" + File.separator + ".." + File.separator + "mq")) {
-                        LOGGER.log(Level.FINE, "Ignoring NoSuchFileException for mq directory under assumption " +
+                        logger.log(Level.FINE, "Ignoring NoSuchFileException for mq directory under assumption " +
                                 "this is a payara-web distribution. Continuing to move files...");
                     } else {
                         throw nsfe;
@@ -647,13 +694,13 @@ public class UpgradeServerCommand extends BaseUpgradeCommand {
                 }
             }
         }
-        LOGGER.log(Level.FINE, "Moved files to old");
+        logger.log(Level.FINE, "Moved files to old");
 
         moveExtracted(newVersion);
     }
 
     private void moveExtracted(Path newVersion) throws IOException {
-        LOGGER.log(Level.FINE, "Copying extracted files");
+        logger.log(Level.FINE, "Copying extracted files");
 
         for (String folder : moveFolders) {
             Path sourcePath = newVersion.resolve("payara5" + File.separator + "glassfish" + File.separator + folder);
@@ -661,10 +708,14 @@ public class UpgradeServerCommand extends BaseUpgradeCommand {
             if (stage) {
                 targetPath = Paths.get(targetPath + ".new");
             }
+            logger.log(Level.FINER, "Moving extracted file {0} to {1}",
+                    new Object[]{sourcePath.toString(), targetPath.toString()});
 
             if (Paths.get(glassfishDir, folder).toFile().isDirectory()) {
                 if (!targetPath.toFile().exists()) {
+                    logger.log(Level.FINER, "Target path {0} doesn't exist, creating it.", targetPath.toString());
                     Files.createDirectory(targetPath);
+                    logger.log(Level.FINEST, "Created target path {0}", targetPath.toString());
                 }
             }
 
@@ -674,48 +725,55 @@ public class UpgradeServerCommand extends BaseUpgradeCommand {
                 Files.walkFileTree(sourcePath, visitor);
             }
         }
-        LOGGER.log(Level.FINE, "Extracted files copied");
+        logger.log(Level.FINE, "Extracted files copied");
     }
 
     private void undoMoveFiles() throws IOException {
         // We don't know the state of the "current" or "old" installs, so we need to do this file by file with
         // a visitor that overwrites rather than doing it by folder with Files.move since Files.move would
         // require us to deal with DirectoryNotEmptyExceptions
-        LOGGER.log(Level.FINE, "Moving old back");
+        logger.log(Level.FINE, "Moving old back");
         for (String folder : moveFolders) {
             try {
                 Path movedToPath = Paths.get(glassfishDir, folder + ".old");
 
                 // Skip this folder if we don't appear to have moved it
                 if (!movedToPath.toFile().exists()) {
+                    logger.log(Level.FINEST, "Moved to path {0} doesn't exist, skipping", movedToPath.toString());
                     continue;
                 }
 
                 // Copy the files from the folder, overwriting any
                 Path movedFromPath = Paths.get(glassfishDir, folder);
                 CopyFileVisitor copyVisitor = new CopyFileVisitor(movedToPath, movedFromPath);
+                logger.log(Level.FINER, "Copying files from {0} to {1}",
+                        new Object[]{movedToPath.toString(), movedFromPath.toString()});
                 Files.walkFileTree(movedToPath, copyVisitor);
+                logger.log(Level.FINEST, "Copied files from {0} to {1}",
+                        new Object[]{movedToPath.toString(), movedFromPath.toString()});
 
                 // Clear out the leftover "old" install
                 DeleteFileVisitor deleteVisitor = new DeleteFileVisitor();
+                logger.log(Level.FINER, "Deleting files from {0}", movedToPath.toString());
                 Files.walkFileTree(movedToPath, deleteVisitor);
+                logger.log(Level.FINEST, "Deleted files from {0}", movedToPath.toString());
             } catch (NoSuchFileException nsfe) {
                 // Don't exit out on NoSuchFileExceptions, just keep going - any NoSuchFileException is likely
                 // just a case of the file not having been moved yet.
-                LOGGER.log(Level.FINE, "Ignoring NoSuchFileException for directory {0} under assumption " +
+                logger.log(Level.FINE, "Ignoring NoSuchFileException for directory {0} under assumption " +
                         "it hasn't been moved yet. Continuing rollback...", folder + ".old");
             }
         }
-        LOGGER.log(Level.FINE, "Moved old back");
+        logger.log(Level.FINE, "Moved old back");
     }
 
     private void fixPermissions() throws IOException {
-        LOGGER.log(Level.FINE, "Fixing file permissions");
+        logger.log(Level.FINE, "Fixing file permissions");
         // Fix the permissions of any bin directories in moveFolders
         fixBinDirPermissions();
         // Fix the permissions of nadmin (since it's not in a bin directory)
         fixNadminPermissions();
-        LOGGER.log(Level.FINE, "File permissions fixed");
+        logger.log(Level.FINE, "File permissions fixed");
     }
 
     private void fixBinDirPermissions() throws IOException {
@@ -738,7 +796,13 @@ public class UpgradeServerCommand extends BaseUpgradeCommand {
             }
 
             if (nadminPath.toFile().exists()) {
+                logger.log(Level.FINER, "Fixing file permissions for {0} to {1}",
+                        new Object[]{nadminPath.toString(), "rwxr-xr-x"});
                 Files.setPosixFilePermissions(nadminPath, PosixFilePermissions.fromString("rwxr-xr-x"));
+                logger.log(Level.FINEST, "Fixed file permissions for {0} to {1}",
+                        new Object[]{nadminPath.toString(), "rwxr-xr-x"});
+            } else {
+                logger.log(Level.FINER, "File {0} does not exist, skipping", nadminPath.toString());
             }
 
             Path nadminBatPath = Paths.get(glassfishDir, "lib", "nadmin.bat");
@@ -747,7 +811,13 @@ public class UpgradeServerCommand extends BaseUpgradeCommand {
             }
 
             if (nadminBatPath.toFile().exists()) {
+                logger.log(Level.FINER, "Fixing file permissions for {0} to {1}",
+                        new Object[]{nadminBatPath.toString(), "rwxr-xr-x"});
                 Files.setPosixFilePermissions(nadminBatPath, PosixFilePermissions.fromString("rwxr-xr-x"));
+                logger.log(Level.FINEST, "Fixed file permissions for {0} to {1}",
+                        new Object[]{nadminBatPath.toString(), "rwxr-xr-x"});
+            } else {
+                logger.log(Level.FINER, "File {0} does not exist, skipping", nadminBatPath.toString());
             }
         }
     }
@@ -766,13 +836,20 @@ public class UpgradeServerCommand extends BaseUpgradeCommand {
             // If we're not in a bin directory, skip
             if (file.getParent().getFileName().toString().equals("bin") ||
                     file.getParent().getFileName().toString().equals("bin.new")) {
-
                 if (!OS.isWindows()) {
-                    LOGGER.log(Level.FINER, "Fixing file permissions for " + file.getFileName());
+                    logger.log(Level.FINER, "Fixing file permissions for {0} to {1}",
+                            new Object[]{file.toString(), "rwxr-xr-x"});
                     Files.setPosixFilePermissions(file, PosixFilePermissions.fromString("rwxr-xr-x"));
+                    logger.log(Level.FINEST, "Fixed file permissions for {0} to {1}",
+                            new Object[]{file.toString(), "rwxr-xr-x"});
+                } else {
+                    logger.log(Level.FINER,
+                            "OS is Windows, skipping fixing file permissions for {0}", file.toString());
                 }
 
                 return FileVisitResult.CONTINUE;
+            } else {
+                logger.log(Level.FINER, "File {0} is not in a bin directory, skipping", file.getParent().toString());
             }
 
             return FileVisitResult.SKIP_SIBLINGS;
@@ -784,16 +861,18 @@ public class UpgradeServerCommand extends BaseUpgradeCommand {
             // optional with "useDownloaded"), so specifically catch a NSFE for the MQ directory.
             if (exc instanceof NoSuchFileException && exc.getMessage().contains(
                     "payara5" + File.separator + "glassfish" + File.separator + ".." + File.separator + "mq")) {
-                LOGGER.log(Level.FINE, "Ignoring NoSuchFileException for mq directory under assumption " +
+                logger.log(Level.FINE, "Ignoring NoSuchFileException for mq directory under assumption " +
                         "this is a payara-web distribution. Continuing fixing of permissions...");
                 return FileVisitResult.SKIP_SUBTREE;
             }
             // osgi-cache directory doesn't exist in a new Payara install so can be safely ignored
             if (exc instanceof NoSuchFileException && exc.getMessage().contains("osgi-cache")) {
+                logger.log(Level.FINE,
+                        "Ignoring NoSuchFileException for osgi-cache directory. Continuing fixing of permissions...");
                 return FileVisitResult.SKIP_SUBTREE;
             }
 
-            LOGGER.log(Level.SEVERE, "File could not visited: {0}", file.toString());
+            logger.log(Level.SEVERE, "File could not visited: {0}", file.toString());
             throw exc;
         }
 

--- a/src/main/java/fish/payara/extras/upgrade/UpgradeServerCommand.java
+++ b/src/main/java/fish/payara/extras/upgrade/UpgradeServerCommand.java
@@ -115,8 +115,9 @@ public class UpgradeServerCommand extends BaseUpgradeCommand {
     private static final String NEXUS_URL = System.getProperty("fish.payara.upgrade.repo.url",
             "https://nexus.payara.fish/repository/payara-enterprise-downloadable-artifacts/fish/payara/distributions/");
     private static final String ZIP = ".zip";
-
     private static final LocalStringsImpl strings = new LocalStringsImpl(CLICommand.class);
+
+    private static final String PERMISSIONS = "rwxr-xr-x";
 
     @Override
     protected void prevalidate() throws CommandException {
@@ -797,10 +798,10 @@ public class UpgradeServerCommand extends BaseUpgradeCommand {
 
             if (nadminPath.toFile().exists()) {
                 logger.log(Level.FINER, "Fixing file permissions for {0} to {1}",
-                        new Object[]{nadminPath.toString(), "rwxr-xr-x"});
-                Files.setPosixFilePermissions(nadminPath, PosixFilePermissions.fromString("rwxr-xr-x"));
+                        new Object[]{nadminPath.toString(), PERMISSIONS});
+                Files.setPosixFilePermissions(nadminPath, PosixFilePermissions.fromString(PERMISSIONS));
                 logger.log(Level.FINEST, "Fixed file permissions for {0} to {1}",
-                        new Object[]{nadminPath.toString(), "rwxr-xr-x"});
+                        new Object[]{nadminPath.toString(), PERMISSIONS});
             } else {
                 logger.log(Level.FINER, "File {0} does not exist, skipping", nadminPath.toString());
             }
@@ -812,10 +813,10 @@ public class UpgradeServerCommand extends BaseUpgradeCommand {
 
             if (nadminBatPath.toFile().exists()) {
                 logger.log(Level.FINER, "Fixing file permissions for {0} to {1}",
-                        new Object[]{nadminBatPath.toString(), "rwxr-xr-x"});
-                Files.setPosixFilePermissions(nadminBatPath, PosixFilePermissions.fromString("rwxr-xr-x"));
+                        new Object[]{nadminBatPath.toString(), PERMISSIONS});
+                Files.setPosixFilePermissions(nadminBatPath, PosixFilePermissions.fromString(PERMISSIONS));
                 logger.log(Level.FINEST, "Fixed file permissions for {0} to {1}",
-                        new Object[]{nadminBatPath.toString(), "rwxr-xr-x"});
+                        new Object[]{nadminBatPath.toString(), PERMISSIONS});
             } else {
                 logger.log(Level.FINER, "File {0} does not exist, skipping", nadminBatPath.toString());
             }
@@ -838,10 +839,10 @@ public class UpgradeServerCommand extends BaseUpgradeCommand {
                     file.getParent().getFileName().toString().equals("bin.new")) {
                 if (!OS.isWindows()) {
                     logger.log(Level.FINER, "Fixing file permissions for {0} to {1}",
-                            new Object[]{file.toString(), "rwxr-xr-x"});
-                    Files.setPosixFilePermissions(file, PosixFilePermissions.fromString("rwxr-xr-x"));
+                            new Object[]{file.toString(), PERMISSIONS});
+                    Files.setPosixFilePermissions(file, PosixFilePermissions.fromString(PERMISSIONS));
                     logger.log(Level.FINEST, "Fixed file permissions for {0} to {1}",
-                            new Object[]{file.toString(), "rwxr-xr-x"});
+                            new Object[]{file.toString(), PERMISSIONS});
                 } else {
                     logger.log(Level.FINER,
                             "OS is Windows, skipping fixing file permissions for {0}", file.toString());

--- a/src/main/java/fish/payara/extras/upgrade/UpgradeServerCommand.java
+++ b/src/main/java/fish/payara/extras/upgrade/UpgradeServerCommand.java
@@ -331,7 +331,7 @@ public class UpgradeServerCommand extends BaseUpgradeCommand {
         // Check if distribution is defined.
         // Continue with upgrade if no defined distribution, user should be able rollback if needed.
         if (versionDistribution.isEmpty()) {
-            logger.log(Level.INFO, "The distribution cannot be validated.");
+            logger.log(Level.WARNING, "The distribution cannot be validated.");
             return;
         }
 


### PR DESCRIPTION
The redundant logger, `Logger LOGGER = Logger.getLogger(CLICommand.class.getPackage().getName())`, is the same as the one inherited from the `CLICommand` class itself, `logger`.

To log messages at level `FINER`, set the environment variable `AS_DEBUG` to _true_, to log messages at level `FINEST`, set the environment variable `AS_TRACE` to _true_.

Signed-off-by: Andrew Pielage <pandrex247@hotmail.com>