### PR TITLE
FISH-6737 Upgrade Tool fails when domain1 has been removed and there are more than 1 domains

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 
     <groupId>fish.payara.extras</groupId>
     <artifactId>payara-upgrade-tool</artifactId>
-    <version>1.5</version>
+    <version>1.6-SNAPSHOT</version>
     <packaging>glassfish-jar</packaging>
     <name>Payara Upgrade Tool</name>
 


### PR DESCRIPTION
By setting the domain name, when the initDomain method gets the domain name for the DomainDirs constructor, it bypasses the need to look for 'domain1' which has been hardcoded. Normally this would cause the command to be executed against that specific domain, but in the case of upgrade tool it will upgrade all domains anyway, so using a specific domain here doesn't change anything. This also maintains the full validation of the domains dir.

Tested with 0 domains, 1 domain, 2 domains (inc domain 1), 2 domains (no domain 1) - All scenarios worked

Pending approval, I will update this to 1.6, release to nexus, tag the release, and increment to 1.7-SNAPSHOT