### PR TITLE
FISH-6630 Resolve Upgrade Tool Expects Payara5

### DIFF
--- a/src/main/java/fish/payara/extras/upgrade/UpgradeServerCommand.java
+++ b/src/main/java/fish/payara/extras/upgrade/UpgradeServerCommand.java
@@ -606,9 +606,15 @@ public class UpgradeServerCommand extends BaseUpgradeCommand {
             try {
                 //Get the version from the downloaded file, validate it then set the version option.
                 options.add(VERSION_PARAM_NAME, getPayaraVersionFromDownload(unzippedDirectory));
-                preventVersionDowngrade();
             } catch (CommandException commandException) {
                 logger.log(Level.SEVERE, "Error getting version from provided zip, aborting upgrade: {0}", commandException.toString());
+                return ERROR;
+            }
+
+            try {
+                preventVersionDowngrade();
+            } catch (CommandException commandException) {
+                logger.log(Level.SEVERE, commandException.toString());
                 return ERROR;
             }
 

--- a/src/main/java/fish/payara/extras/upgrade/UpgradeServerCommand.java
+++ b/src/main/java/fish/payara/extras/upgrade/UpgradeServerCommand.java
@@ -673,7 +673,7 @@ public class UpgradeServerCommand extends BaseUpgradeCommand {
         if (stage) {
             logger.log(Level.INFO,
                     "Upgrade successfully staged, please run the applyStagedUpgrade script to apply the upgrade. " +
-                            "It can be found under payara5/glassfish/bin.");
+                            "It can be found under payara" + getCurrentMajorVersion() + "/glassfish/bin.");
         }
 
         return SUCCESS;
@@ -873,7 +873,7 @@ public class UpgradeServerCommand extends BaseUpgradeCommand {
     }
 
     private void fixNadminPermissions() throws IOException {
-        // Check that we're actually upgrading the payara5/glassfish/lib directory before messing with permissions
+        // Check that we're actually upgrading the payara(5/6)/glassfish/lib directory before messing with permissions
         if (Arrays.stream(moveFolders).anyMatch(folder -> folder.equals("lib"))) {
             Path nadminPath = Paths.get(glassfishDir, "lib", "nadmin");
             if (stage) {


### PR DESCRIPTION
Currently upgrade tool doesn't let you downgrade between versions, however there is no version validation when using `--usedownloaded` so it will allow you to downgrade. This is because when using a downloaded version the Upgrade Tool doesn't know what version of Payara is being used.

This introduces a method to go into the glassfish-version.properties file and extract the Payara version. Therefore now knowing the major version, where possible I have removed hard-coded references to the `payara5` directory and replaced them with using the upgrade major version.

Tested and this no longer allows you to downgrade between Payara 5 versions. It also allows you to progress further into the upgrade, there are other known issues preventing the upgrade from happening but the error expecting Payara5 is gone