### PR TITLE
FISH-7099 Payara5 and Payara6 Version Validation

### DIFF
--- a/src/main/java/fish/payara/extras/upgrade/UpgradeServerCommand.java
+++ b/src/main/java/fish/payara/extras/upgrade/UpgradeServerCommand.java
@@ -225,6 +225,16 @@ public class UpgradeServerCommand extends BaseUpgradeCommand {
                     throw new CommandValidationException(message);
                 }
             } else {
+                //To provide a helpful error, check if the version was likely a community version
+                Pattern communityPattern = Pattern.compile("([0-9]{1,2})\\.([0-9]{4})\\.([0-9]{1,2})(?!\\W\\w+)");
+                Matcher communityMatcher = communityPattern.matcher(selectedVersion);
+                if (communityMatcher.find()) {
+                    String message = String.format("%s is a Payara Community version. You can only upgrade to a Payara Enterprise version",
+                            selectedVersion);
+                    throw new CommandValidationException(message);
+                }
+
+                //If it wasn't a community version it's likely random text
                 String message = String.format("Invalid selected version %s, please verify and try again",
                         selectedVersion);
                 throw new CommandValidationException(message);

--- a/src/test/java/fish/payara/extras/upgrade/UpgradeServerCommandTest.java
+++ b/src/test/java/fish/payara/extras/upgrade/UpgradeServerCommandTest.java
@@ -172,7 +172,7 @@ public class UpgradeServerCommandTest extends TestCase {
     }
 
     @Test
-    public void testVersionUpgrade() {
+    public void testPayara5EnterpriseToPayara6Enterprise() {
         List<String> selectedVersionList = new ArrayList<>();
         selectedVersionList.add("6.1.0");
 
@@ -191,6 +191,58 @@ public class UpgradeServerCommandTest extends TestCase {
         verify(upgradeServerCommand, times(1)).getCurrentMinorVersion();
         verify(upgradeServerCommand, times(1)).getCurrentMinorVersion();
 
+    }
+
+    @Test
+    public void testPayara5EnterpriseToPayara6Community() {
+        List<String> selectedVersionList = new ArrayList<>();
+        selectedVersionList.add("6.2023.2");
+
+        doReturn(selectedVersionList).when(upgradeServerCommand).getVersion();
+
+        try {
+            upgradeServerCommand.preventVersionDowngrade();
+        } catch (CommandValidationException e) {
+            assertTrue(e.getMessage().contains("6.2023.2 is a Payara Community version. You can only upgrade to a Payara Enterprise version"));
+            verify(upgradeServerCommand, times(1)).getVersion();
+        }
+    }
+
+    @Test
+    public void testPayara6EnterpriseToPayara6Community() {
+        List<String> selectedVersionList = new ArrayList<>();
+        selectedVersionList.add("6.2023.1");
+
+        doReturn(selectedVersionList).when(upgradeServerCommand).getVersion();
+
+        try {
+            upgradeServerCommand.preventVersionDowngrade();
+        } catch (CommandValidationException e) {
+            assertTrue(e.getMessage().contains("6.2023.1 is a Payara Community version. You can only upgrade to a Payara Enterprise version"));
+            verify(upgradeServerCommand, times(1)).getVersion();
+        }
+    }
+
+    @Test
+    public void testPayara6EnterpriseToPayara6Enterprise() {
+        List<String> selectedVersionList = new ArrayList<>();
+        selectedVersionList.add("6.1.0");
+
+        doReturn(selectedVersionList).when(upgradeServerCommand).getVersion();
+        doReturn("6").when(upgradeServerCommand).getCurrentMajorVersion();
+        doReturn("0").when(upgradeServerCommand).getCurrentMinorVersion();
+        doReturn("0").when(upgradeServerCommand).getCurrentUpdatedVersion();
+
+        try {
+            upgradeServerCommand.preventVersionDowngrade();
+        } catch (CommandValidationException e) {
+            Assert.fail("Version validation failed incorrectly. " + e.getMessage());
+        }
+
+        verify(upgradeServerCommand, times(1)).getVersion();
+        verify(upgradeServerCommand, times(1)).getCurrentMajorVersion();
+        verify(upgradeServerCommand, times(1)).getCurrentMinorVersion();
+        verify(upgradeServerCommand, times(1)).getCurrentMinorVersion();
     }
 
     @Test


### PR DESCRIPTION
Unit tests for version validation with combinations of Payara 5 and Payara 6 distributions. Updates one of the error messages to be more informative for the user.

Also manually tested this with `--usedownloaded` and works as expected.