### PR TITLE
FISH-7093 FISH-7094 FISH-7277 Update Move Folders and MQ Error Handling for Payara 5 to Payara 6, and Check for JDK 11 if Upgrading to Payara 6 (Payara6)

### DIFF
--- a/src/main/java/fish/payara/extras/upgrade/RollbackUpgradeCommand.java
+++ b/src/main/java/fish/payara/extras/upgrade/RollbackUpgradeCommand.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2020-2022 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020-2023 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -113,14 +113,24 @@ public class RollbackUpgradeCommand extends BaseUpgradeCommand {
                             "payara5" + File.separator + "glassfish" + File.separator + ".." + File.separator + "mq")) {
                         logger.log(Level.FINE, "Ignoring NoSuchFileException for mq directory under assumption " +
                                 "this is a payara-web distribution. Continuing to move files...");
+                        continue;
+                    }
+
                     // osgi-cache directory is created when the domain is started, if it was never started the
                     // directory will not exist so it's safe to ignore the NSFE
-                    } if (nsfe.getMessage().contains("osgi-cache")) {
+                    if (nsfe.getMessage().contains("osgi-cache")) {
                         logger.log(Level.FINE, "Ignoring NoSuchFileException for osgi-cache directory under the " +
                                 "assumption the upgraded domain was never started. Continuing to move files...");
-                    } else {
-                        throw nsfe;
+                        continue;
                     }
+
+                    if (nsfe.getMessage().contains("glassfish/h2db")) {
+                        logger.log(Level.FINE, "Ignoring NoSuchFileException for glassfish/h2db directory under the " +
+                                "assumption this is a Payara 6 installation. Continuing to move files...");
+                        continue;
+                    }
+
+                    throw nsfe;
                 }
             }
             logger.log(Level.FINE, "Moved current install into a staged rollback directory");
@@ -157,15 +167,24 @@ public class RollbackUpgradeCommand extends BaseUpgradeCommand {
                             "payara5" + File.separator + "glassfish" + File.separator + ".." + File.separator + "mq")) {
                         logger.log(Level.FINE, "Ignoring NoSuchFileException for mq directory under assumption " +
                                 "this is a payara-web distribution. Continuing to move files...");
+                        continue;
                     }
+
                     // osgi-cache directory is created when the domain is started, if it was never started before the
                     // upgrade the directory will not exist so it's safe to ignore the NSFE
                     if (nsfe.getMessage().contains("osgi-cache")) {
                         logger.log(Level.FINE, "Ignoring NoSuchFileException for osgi-cache directory under the " +
                             "assumption the upgraded domain was never started. Continuing to move files...");
-                    } else {
-                        throw nsfe;
+                        continue;
                     }
+
+                    if (nsfe.getMessage().contains("glassfish/h2db")) {
+                        logger.log(Level.FINE, "Ignoring NoSuchFileException for glassfish/h2db directory under the " +
+                                "assumption this is a Payara 6 installation. Continuing to move files...");
+                        continue;
+                    }
+
+                    throw nsfe;
                 }
             }
         } catch (IOException ioe) {

--- a/src/main/java/fish/payara/extras/upgrade/RollbackUpgradeCommand.java
+++ b/src/main/java/fish/payara/extras/upgrade/RollbackUpgradeCommand.java
@@ -107,10 +107,8 @@ public class RollbackUpgradeCommand extends BaseUpgradeCommand {
                     logger.log(Level.FINEST, "Moved {0} into staged rollback directory {1}",
                             new Object[]{currentDirectory.toString(), newDirectory.toString()});
                 } catch (NoSuchFileException nsfe) {
-                    // We can't nicely check if the current or old installation is a web distribution or not, so just
-                    // attempt to move all and specifically catch a NSFE for the MQ directory
-                    if (nsfe.getMessage().contains(
-                            "payara5" + File.separator + "glassfish" + File.separator + ".." + File.separator + "mq")) {
+                    if (nsfe.getMessage().contains("glassfish" + File.separator + ".." + File.separator + "mq")
+                            && isWebDistributionUpgrade) {
                         logger.log(Level.FINE, "Ignoring NoSuchFileException for mq directory under assumption " +
                                 "this is a payara-web distribution. Continuing to move files...");
                         continue;
@@ -161,10 +159,8 @@ public class RollbackUpgradeCommand extends BaseUpgradeCommand {
                     logger.log(Level.FINEST, "Moved old directory {0} into current install directory {1}",
                             new Object[]{oldDirectory.toString(), currentDirectory.toString()});
                 } catch (NoSuchFileException nsfe) {
-                    // We can't nicely check if the current or old installation is a web distribution or not, so just
-                    // attempt to move all and specifically catch a NSFE for the MQ directory
-                    if (nsfe.getMessage().contains(
-                            "payara5" + File.separator + "glassfish" + File.separator + ".." + File.separator + "mq")) {
+                    if (nsfe.getMessage().contains("glassfish" + File.separator + ".." + File.separator + "mq")
+                            && isWebDistributionUpgrade) {
                         logger.log(Level.FINE, "Ignoring NoSuchFileException for mq directory under assumption " +
                                 "this is a payara-web distribution. Continuing to move files...");
                         continue;

--- a/src/main/java/fish/payara/extras/upgrade/RollbackUpgradeCommand.java
+++ b/src/main/java/fish/payara/extras/upgrade/RollbackUpgradeCommand.java
@@ -126,7 +126,7 @@ public class RollbackUpgradeCommand extends BaseUpgradeCommand {
 
                     if (nsfe.getMessage().contains("glassfish/h2db")) {
                         logger.log(Level.FINE, "Ignoring NoSuchFileException for glassfish/h2db directory under the " +
-                                "assumption this is a Payara 6 installation. Continuing to move files...");
+                                "assumption this is a distribution without the duplicate directory. Continuing to move files...");
                         continue;
                     }
 
@@ -180,7 +180,7 @@ public class RollbackUpgradeCommand extends BaseUpgradeCommand {
 
                     if (nsfe.getMessage().contains("glassfish/h2db")) {
                         logger.log(Level.FINE, "Ignoring NoSuchFileException for glassfish/h2db directory under the " +
-                                "assumption this is a Payara 6 installation. Continuing to move files...");
+                                "assumption this is a distribution without the duplicate directory. Continuing to move files...");
                         continue;
                     }
 

--- a/src/main/java/fish/payara/extras/upgrade/UpgradeServerCommand.java
+++ b/src/main/java/fish/payara/extras/upgrade/UpgradeServerCommand.java
@@ -357,21 +357,14 @@ public class UpgradeServerCommand extends BaseUpgradeCommand {
             }
 
             int majorSelectedVersion = Integer.parseInt(matcher.group(1).trim());
-            int majorCurrentVersion = Integer.parseInt(getCurrentMajorVersion());
-
             if (majorSelectedVersion == 6) {
                 isPayara6Upgrade = true;
             }
 
-            if (majorSelectedVersion <= majorCurrentVersion) {
-                int minorSelectedVersion = Integer.parseInt(matcher.group(2).trim());
-                int updateSelectedVersion = Integer.parseInt(matcher.group(3).trim());
-                int minorCurrentVersion = Integer.parseInt(getCurrentMinorVersion());
-                int updatedCurrentVersion = Integer.parseInt(getCurrentUpdatedVersion());
-
-                preventVersionDowngrade(selectedVersion, majorSelectedVersion, majorCurrentVersion,
-                        minorSelectedVersion, minorCurrentVersion, updateSelectedVersion, updatedCurrentVersion);
-            }
+            preventVersionDowngrade(selectedVersion,
+                    majorSelectedVersion, Integer.parseInt(getCurrentMajorVersion()),
+                    Integer.parseInt(matcher.group(2).trim()), Integer.parseInt(getCurrentMinorVersion()),
+                    Integer.parseInt(matcher.group(3).trim()), Integer.parseInt(getCurrentUpdatedVersion()));
         } else {
             //To provide a helpful error, check if the version was likely a community version
             Pattern communityPattern = Pattern.compile("([0-9]{1,2})\\.([0-9]{4})\\.([0-9]{1,2})(?!\\W\\w+)");
@@ -395,7 +388,8 @@ public class UpgradeServerCommand extends BaseUpgradeCommand {
      *
      * @throws CommandValidationException
      */
-    private void preventVersionDowngrade(String selectedVersion, int majorSelectedVersion, int majorCurrentVersion,
+    private void preventVersionDowngrade(String selectedVersion,
+            int majorSelectedVersion, int majorCurrentVersion,
             int minorSelectedVersion, int minorCurrentVersion,
             int updateSelectedVersion, int updatedCurrentVersion) throws CommandValidationException {
         StringBuilder buildCurrentVersion = new StringBuilder().append(majorCurrentVersion).append(".")

--- a/src/main/java/fish/payara/extras/upgrade/UpgradeServerCommand.java
+++ b/src/main/java/fish/payara/extras/upgrade/UpgradeServerCommand.java
@@ -121,7 +121,7 @@ public class UpgradeServerCommand extends BaseUpgradeCommand {
 
     private static final String PERMISSIONS = "rwxr-xr-x";
 
-    private boolean isMajorVersionUpgrade = false;
+    private boolean isPayara6Upgrade = false;
 
     @Override
     protected void prevalidate() throws CommandException {
@@ -355,9 +355,11 @@ public class UpgradeServerCommand extends BaseUpgradeCommand {
                 int majorSelectedVersion = Integer.parseInt(matcher.group(1).trim());
                 int majorCurrentVersion = Integer.parseInt(getCurrentMajorVersion());
 
-                if (majorSelectedVersion > majorCurrentVersion) {
-                    isMajorVersionUpgrade = true;
-                } else {
+                if (majorSelectedVersion == 6) {
+                    isPayara6Upgrade = true;
+                }
+
+                if (majorSelectedVersion <= majorCurrentVersion) {
                     int minorSelectedVersion = Integer.parseInt(matcher.group(2).trim());
                     int updateSelectedVersion = Integer.parseInt(matcher.group(3).trim());
                     int minorCurrentVersion = Integer.parseInt(getCurrentMinorVersion());
@@ -848,7 +850,7 @@ public class UpgradeServerCommand extends BaseUpgradeCommand {
 
             // Check that the path actually exists - some folders may have moved or be different between versions
             // For example glassfish/h2db exists for Payara 5, but doesn't for Payara 6
-            if (isMajorVersionUpgrade && !Files.exists(sourcePath)) {
+            if (isPayara6Upgrade && !Files.exists(sourcePath)) {
                 logger.log(Level.FINER, "Source path {0} doesn't exist, skipping...", sourcePath.toString());
                 continue;
             }
@@ -1021,7 +1023,7 @@ public class UpgradeServerCommand extends BaseUpgradeCommand {
                 return FileVisitResult.SKIP_SUBTREE;
             }
             // glassfish/h2db directory doesn't exist in a Payara 6 install so can be safely ignored
-            if (isMajorVersionUpgrade && exc instanceof NoSuchFileException && exc.getMessage().contains("glassfish/h2db")) {
+            if (isPayara6Upgrade && exc instanceof NoSuchFileException && exc.getMessage().contains("glassfish/h2db")) {
                 logger.log(Level.FINE,
                         "Ignoring NoSuchFileException for glassfish/h2db directory. Continuing fixing of permissions...");
                 return FileVisitResult.SKIP_SUBTREE;

--- a/src/main/java/fish/payara/extras/upgrade/UpgradeServerCommand.java
+++ b/src/main/java/fish/payara/extras/upgrade/UpgradeServerCommand.java
@@ -341,50 +341,50 @@ public class UpgradeServerCommand extends BaseUpgradeCommand {
      */
     protected void validateVersions() throws CommandValidationException {
         List<String> versionList = getVersion();
-        if (!versionList.isEmpty()) {
-            String selectedVersion = versionList.get(0).trim();
-            Pattern pattern = Pattern.compile("([0-9]{1,2})\\.([0-9]{1,2})\\.([0-9]{1,2})(?!\\W\\w+)");
-            Matcher matcher = pattern.matcher(selectedVersion);
-            if (matcher.find()) {
-                if (matcher.groupCount() != 3) {
-                    String message = String.format("Invalid selected version %s, please verify and try again",
-                            selectedVersion);
-                    throw new CommandValidationException(message);
-                }
+        if (versionList.isEmpty()) {
+            String message = "Empty selected version, please verify and try again";
+            throw new CommandValidationException(message);
+        }
 
-                int majorSelectedVersion = Integer.parseInt(matcher.group(1).trim());
-                int majorCurrentVersion = Integer.parseInt(getCurrentMajorVersion());
-
-                if (majorSelectedVersion == 6) {
-                    isPayara6Upgrade = true;
-                }
-
-                if (majorSelectedVersion <= majorCurrentVersion) {
-                    int minorSelectedVersion = Integer.parseInt(matcher.group(2).trim());
-                    int updateSelectedVersion = Integer.parseInt(matcher.group(3).trim());
-                    int minorCurrentVersion = Integer.parseInt(getCurrentMinorVersion());
-                    int updatedCurrentVersion = Integer.parseInt(getCurrentUpdatedVersion());
-
-                    preventVersionDowngrade(selectedVersion, majorSelectedVersion, majorCurrentVersion,
-                            minorSelectedVersion, minorCurrentVersion, updateSelectedVersion, updatedCurrentVersion);
-                }
-            } else {
-                //To provide a helpful error, check if the version was likely a community version
-                Pattern communityPattern = Pattern.compile("([0-9]{1,2})\\.([0-9]{4})\\.([0-9]{1,2})(?!\\W\\w+)");
-                Matcher communityMatcher = communityPattern.matcher(selectedVersion);
-                if (communityMatcher.find()) {
-                    String message = String.format("%s is a Payara Community version. You can only upgrade to a Payara Enterprise version",
-                            selectedVersion);
-                    throw new CommandValidationException(message);
-                }
-
-                //If it wasn't a community version it's likely random text
+        String selectedVersion = versionList.get(0).trim();
+        Pattern pattern = Pattern.compile("([0-9]{1,2})\\.([0-9]{1,2})\\.([0-9]{1,2})(?!\\W\\w+)");
+        Matcher matcher = pattern.matcher(selectedVersion);
+        if (matcher.find()) {
+            if (matcher.groupCount() != 3) {
                 String message = String.format("Invalid selected version %s, please verify and try again",
                         selectedVersion);
                 throw new CommandValidationException(message);
             }
+
+            int majorSelectedVersion = Integer.parseInt(matcher.group(1).trim());
+            int majorCurrentVersion = Integer.parseInt(getCurrentMajorVersion());
+
+            if (majorSelectedVersion == 6) {
+                isPayara6Upgrade = true;
+            }
+
+            if (majorSelectedVersion <= majorCurrentVersion) {
+                int minorSelectedVersion = Integer.parseInt(matcher.group(2).trim());
+                int updateSelectedVersion = Integer.parseInt(matcher.group(3).trim());
+                int minorCurrentVersion = Integer.parseInt(getCurrentMinorVersion());
+                int updatedCurrentVersion = Integer.parseInt(getCurrentUpdatedVersion());
+
+                preventVersionDowngrade(selectedVersion, majorSelectedVersion, majorCurrentVersion,
+                        minorSelectedVersion, minorCurrentVersion, updateSelectedVersion, updatedCurrentVersion);
+            }
         } else {
-            String message = "Empty selected version, please verify and try again";
+            //To provide a helpful error, check if the version was likely a community version
+            Pattern communityPattern = Pattern.compile("([0-9]{1,2})\\.([0-9]{4})\\.([0-9]{1,2})(?!\\W\\w+)");
+            Matcher communityMatcher = communityPattern.matcher(selectedVersion);
+            if (communityMatcher.find()) {
+                String message = String.format("%s is a Payara Community version. You can only upgrade to a Payara Enterprise version",
+                        selectedVersion);
+                throw new CommandValidationException(message);
+            }
+
+            //If it wasn't a community version it's likely random text
+            String message = String.format("Invalid selected version %s, please verify and try again",
+                    selectedVersion);
             throw new CommandValidationException(message);
         }
     }

--- a/src/main/java/fish/payara/extras/upgrade/UpgradeServerCommand.java
+++ b/src/main/java/fish/payara/extras/upgrade/UpgradeServerCommand.java
@@ -808,15 +808,26 @@ public class UpgradeServerCommand extends BaseUpgradeCommand {
         logger.log(Level.FINE, "Copying extracted files");
 
         for (String folder : moveFolders) {
-            Path sourcePath = newVersion.resolve("payara" + getUpgradeMajorVersion() + File.separator + "glassfish" + File.separator + folder);
+            Path sourcePath = newVersion.resolve(
+                    "payara" + getUpgradeMajorVersion() + File.separator + "glassfish" + File.separator + folder);
 
             // Check that the path actually exists - some folders may have moved or be different between versions
             // For example some versions of Payara 5 have a duplicate glassfish/h2db directory
-            if (!Files.exists(sourcePath) && sourcePath.endsWith("glassfish" + File.separator + "h2db")) {
-                logger.log(Level.FINER,
-                        "Source path {0} doesn't exist, skipping under assumption this is a distribution without the duplicate directory...",
-                        sourcePath.toString());
-                continue;
+            if (!Files.exists(sourcePath)) {
+                if (sourcePath.endsWith("glassfish" + File.separator + "h2db")) {
+                    logger.log(Level.FINER,
+                            "Source path {0} doesn't exist, skipping under assumption this is a distribution without the duplicate directory...",
+                            sourcePath.toString());
+                    continue;
+                }
+
+                if (sourcePath.endsWith("glassfish" + File.separator + ".." + File.separator + "mq")
+                        && isWebDistributionUpgrade) {
+                    logger.log(Level.FINER,
+                            "Source path {0} doesn't exist, skipping under assumption this is a payara-web distribution...",
+                            sourcePath.toString());
+                    continue;
+                }
             }
 
             Path targetPath = Paths.get(glassfishDir, folder);

--- a/src/main/java/fish/payara/extras/upgrade/UpgradeServerCommand.java
+++ b/src/main/java/fish/payara/extras/upgrade/UpgradeServerCommand.java
@@ -821,6 +821,7 @@ public class UpgradeServerCommand extends BaseUpgradeCommand {
                     continue;
                 }
 
+                // Check for the usual MQ missing in payara-web case
                 if (sourcePath.endsWith("glassfish" + File.separator + ".." + File.separator + "mq")
                         && isWebDistributionUpgrade) {
                     logger.log(Level.FINER,

--- a/src/test/java/fish/payara/extras/upgrade/UpgradeServerCommandTest.java
+++ b/src/test/java/fish/payara/extras/upgrade/UpgradeServerCommandTest.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2021] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021-2023 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -79,7 +79,7 @@ public class UpgradeServerCommandTest extends TestCase {
         doReturn("0").when(upgradeServerCommand).getCurrentUpdatedVersion();
 
         try {
-            upgradeServerCommand.preventVersionDowngrade();
+            upgradeServerCommand.validateVersions();
         } catch (CommandValidationException e) {
             assertTrue(e.getMessage().contains("The version indicated is incorrect"));
             verify(upgradeServerCommand, times(1)).getVersion();
@@ -98,7 +98,7 @@ public class UpgradeServerCommandTest extends TestCase {
         doReturn(selectedVersionList).when(upgradeServerCommand).getVersion();
 
         try {
-            upgradeServerCommand.preventVersionDowngrade();
+            upgradeServerCommand.validateVersions();
         } catch (CommandValidationException e) {
             assertTrue(e.getMessage().contains("Invalid selected version"));
             verify(upgradeServerCommand, times(1)).getVersion();
@@ -114,7 +114,7 @@ public class UpgradeServerCommandTest extends TestCase {
         doReturn(selectedVersionList).when(upgradeServerCommand).getVersion();
 
         try {
-            upgradeServerCommand.preventVersionDowngrade();
+            upgradeServerCommand.validateVersions();
         } catch (CommandValidationException e) {
             assertTrue(e.getMessage().contains("Invalid selected version"));
             verify(upgradeServerCommand, times(1)).getVersion();
@@ -129,7 +129,7 @@ public class UpgradeServerCommandTest extends TestCase {
         doReturn(selectedVersionList).when(upgradeServerCommand).getVersion();
 
         try {
-            upgradeServerCommand.preventVersionDowngrade();
+            upgradeServerCommand.validateVersions();
         } catch (CommandValidationException e) {
             assertTrue(e.getMessage().contains("Invalid selected version"));
             verify(upgradeServerCommand, times(1)).getVersion();
@@ -143,7 +143,7 @@ public class UpgradeServerCommandTest extends TestCase {
         doReturn(selectedVersionList).when(upgradeServerCommand).getVersion();
 
         try {
-            upgradeServerCommand.preventVersionDowngrade();
+            upgradeServerCommand.validateVersions();
         } catch (CommandValidationException e) {
             assertTrue(e.getMessage().contains("Empty selected version"));
             verify(upgradeServerCommand, times(1)).getVersion();
@@ -161,7 +161,7 @@ public class UpgradeServerCommandTest extends TestCase {
         doReturn("0").when(upgradeServerCommand).getCurrentUpdatedVersion();
 
         try {
-            upgradeServerCommand.preventVersionDowngrade();
+            upgradeServerCommand.validateVersions();
         } catch (CommandValidationException e) {
             assertTrue(e.getMessage().contains("It was selected the same version"));
             verify(upgradeServerCommand, times(1)).getVersion();
@@ -182,7 +182,7 @@ public class UpgradeServerCommandTest extends TestCase {
         doReturn("0").when(upgradeServerCommand).getCurrentUpdatedVersion();
 
         try {
-            upgradeServerCommand.preventVersionDowngrade();
+            upgradeServerCommand.validateVersions();
         } catch (CommandValidationException e) {
             Assert.fail("Exception thrown");
         }
@@ -201,7 +201,7 @@ public class UpgradeServerCommandTest extends TestCase {
         doReturn(selectedVersionList).when(upgradeServerCommand).getVersion();
 
         try {
-            upgradeServerCommand.preventVersionDowngrade();
+            upgradeServerCommand.validateVersions();
         } catch (CommandValidationException e) {
             assertTrue(e.getMessage().contains("6.2023.2 is a Payara Community version. You can only upgrade to a Payara Enterprise version"));
             verify(upgradeServerCommand, times(1)).getVersion();
@@ -216,7 +216,7 @@ public class UpgradeServerCommandTest extends TestCase {
         doReturn(selectedVersionList).when(upgradeServerCommand).getVersion();
 
         try {
-            upgradeServerCommand.preventVersionDowngrade();
+            upgradeServerCommand.validateVersions();
         } catch (CommandValidationException e) {
             assertTrue(e.getMessage().contains("6.2023.1 is a Payara Community version. You can only upgrade to a Payara Enterprise version"));
             verify(upgradeServerCommand, times(1)).getVersion();
@@ -234,7 +234,7 @@ public class UpgradeServerCommandTest extends TestCase {
         doReturn("0").when(upgradeServerCommand).getCurrentUpdatedVersion();
 
         try {
-            upgradeServerCommand.preventVersionDowngrade();
+            upgradeServerCommand.validateVersions();
         } catch (CommandValidationException e) {
             Assert.fail("Version validation failed incorrectly. " + e.getMessage());
         }


### PR DESCRIPTION
Allows the upgrade to continue if a folder is deemed to be missing when upgrading from 5 to 6 (e.g. the H2DB folder).

Also moves the version validation to the validate stage, since it shouldn't really have been in the rpevalidate stage anyway - prevalidate is for checking that variables are present, not that they're correct.

Now also adds updated handling for MQ

Now also includes a check for if upgrading to Payara 6 to validate that JDK 11 is being used.
